### PR TITLE
fix redis parser array

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.1-SNAPSHOT
+version=1.0.1-SNAPSHOT

--- a/src/main/java/com/github/tonivade/resp/protocol/RedisParser.java
+++ b/src/main/java/com/github/tonivade/resp/protocol/RedisParser.java
@@ -82,23 +82,23 @@ public class RedisParser implements Iterator<RedisToken> {
   }
 
   private RedisToken parseStringToken(SafeString line) {
-    StringRedisToken token;
     int length = line.parseIntAfterPrefix();
     if (length >= 0 && length < maxLength) {
-      token = new StringRedisToken(source.readString(length));
-    } else {
-      token = new StringRedisToken(SafeString.EMPTY_STRING);
+      return new StringRedisToken(source.readString(length));
     }
-    return token;
+    return new StringRedisToken(SafeString.EMPTY_STRING);
   }
 
   private RedisToken parseArray(int size) {
-    List<RedisToken> array = new ArrayList<>(size);
+    if (size >= 0 && size < maxLength) {
+      List<RedisToken> array = new ArrayList<>(size);
 
-    for (int i = 0; i < size; i++) {
-      array.add(parseToken(source.readLine()));
+      for (int i = 0; i < size; i++) {
+        array.add(parseToken(source.readLine()));
+      }
+
+      return array(array);
     }
-
-    return array(array);
+    return array();
   }
 }

--- a/src/test/java/com/github/tonivade/resp/protocol/RedisParserTest.java
+++ b/src/test/java/com/github/tonivade/resp/protocol/RedisParserTest.java
@@ -6,6 +6,7 @@ package com.github.tonivade.resp.protocol;
 
 import com.github.tonivade.resp.protocol.AbstractRedisToken.UnknownRedisToken;
 import com.github.tonivade.resp.util.StringRedisSource;
+
 import org.junit.jupiter.api.Test;
 
 import static com.github.tonivade.resp.protocol.SafeString.safeString;
@@ -44,6 +45,15 @@ class RedisParserTest {
 
     assertThat(token, equalTo(emptyString));
     assertThat(source.available(), equalTo(0));
+  }
+
+  @Test
+  void testLargeBulkString() {
+    source.init("$100000\r\n\r\n");
+
+    RedisToken token = parser.next();
+
+    assertThat(token, equalTo(emptyString));
   }
 
   @Test
@@ -99,5 +109,19 @@ class RedisParserTest {
 
     assertThat(token, equalTo(arrayToken));
     assertThat(source.available(), equalTo(0));
+  }
+
+  @Test
+  void testLargeArray() throws Exception {
+    source.init(
+      "*100000\r\n",
+      ":1\r\n",
+      "$3\r\n",
+      "abc\r\n"
+    );
+
+    RedisToken token = parser.next();
+
+    assertThat(token, equalTo(RedisToken.array()));
   }
 }


### PR DESCRIPTION
fixes CWE-400 (Uncontrolled Resource Consumption) on RedisParser when parsing an array.

There's no array size check and it can lead to a out of memory error.